### PR TITLE
Revert linux.preset

### DIFF
--- a/.SRCINFO
+++ b/.SRCINFO
@@ -23,7 +23,7 @@ pkgbase = linux-amd-staging-drm-next-git
 	sha256sums = b8d1fd75825a59312e347674f8a13b799e0535109da6218763c5b21c1e071168
 	sha256sums = ae2e95db94ef7176207c690224169594d49445e04249d2499e9d2fbc117a0b21
 	sha256sums = ae2e95db94ef7176207c690224169594d49445e04249d2499e9d2fbc117a0b21
-	sha256sums = 997dd1ca5c59e526a35d8367e6371a68406b1a58b90006e6f85d59a580c7503f
+	sha256sums = ad6344badc91ad0630caacde83f7f9b97276f80d26a20619a87952be65492c65
 
 pkgname = linux-amd-staging-drm-next-git
 	pkgdesc = The Linux-amd-staging-drm-next-git kernel and modules

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -28,7 +28,7 @@ sha256sums=('SKIP'
             'b8d1fd75825a59312e347674f8a13b799e0535109da6218763c5b21c1e071168'
             'ae2e95db94ef7176207c690224169594d49445e04249d2499e9d2fbc117a0b21'
             'ae2e95db94ef7176207c690224169594d49445e04249d2499e9d2fbc117a0b21'
-            '997dd1ca5c59e526a35d8367e6371a68406b1a58b90006e6f85d59a580c7503f')
+            'ad6344badc91ad0630caacde83f7f9b97276f80d26a20619a87952be65492c65')
 pkgver() {
   cd "${_srcname}"
   local version="$(grep \^VERSION Makefile|cut -d"=" -f2|cut -d" " -f2)"

--- a/linux.preset
+++ b/linux.preset
@@ -1,27 +1,14 @@
-post_install () {
-  # updating module dependencies
-  echo ">>> Updating module dependencies. Please wait ..."
-  depmod %KERNVER%
-}
+# mkinitcpio preset file for the '%PKGBASE%' package
 
-post_upgrade() {
-  if findmnt --fstab -uno SOURCE /boot &>/dev/null && ! mountpoint -q /boot; then
-    echo "WARNING: /boot appears to be a separate partition but is not mounted."
-  fi
+ALL_config="/etc/mkinitcpio.conf"
+ALL_kver="/boot/vmlinuz-%PKGBASE%"
 
-  # updating module dependencies
-  echo ">>> Updating module dependencies. Please wait ..."
-  depmod %KERNVER%
+PRESETS=('default' 'fallback')
 
-  if [ $(vercmp $2 3.13) -lt 0 ]; then
-    echo ">>> WARNING: AT keyboard support is no longer built into the kernel."
-    echo ">>>          In order to use your keyboard during early init, you MUST"
-    echo ">>>          include the 'keyboard' hook in your mkinitcpio.conf."
-  fi
-}
+#default_config="/etc/mkinitcpio.conf"
+default_image="/boot/initramfs-%PKGBASE%.img"
+#default_options=""
 
-post_remove() {
-  # also remove the compat symlinks
-  rm -f boot/initramfs-%PKGBASE%.img
-  rm -f boot/initramfs-%PKGBASE%-fallback.img
-}
+#fallback_config="/etc/mkinitcpio.conf"
+fallback_image="/boot/initramfs-%PKGBASE%-fallback.img"
+fallback_options="-S autodetect"


### PR DESCRIPTION
In commit https://github.com/yurikoles-aur/linux-amd-staging-drm-next-git/commit/fb77e81fc80f5b734923b5ccc8313e13be859de7 _linux.preset_ was (accidentally?) overwritten with a copy of _linux.install_ which breaks `mkinitcpio`.

Should fix https://aur.archlinux.org/packages/linux-amd-staging-drm-next-git#comment-707384